### PR TITLE
Show homepage map by default (apps/web)

### DIFF
--- a/apps/web/src/components/HomePageContent.astro
+++ b/apps/web/src/components/HomePageContent.astro
@@ -78,30 +78,13 @@ const mapEmbedUrl =
 
       <div class="min-h-[300px] rounded overflow-hidden bg-gray-100">
         {mapEmbedUrl ? (
-          <div
-            class="w-full h-[300px] flex flex-col items-center justify-center gap-3 text-center px-6"
-            data-map-container
-            data-map-src={mapEmbedUrl}
-          >
-            <span class="text-gray-600 text-sm">Карта загрузится по запросу</span>
-            <button
-              type="button"
-              class="inline-flex items-center justify-center px-4 py-2 text-white rounded hover:opacity-90 transition-opacity"
-              style="background-color: #1371AF;"
-              data-map-load
-            >
-              Показать карту
-            </button>
-            <noscript>
-              <iframe
-                title="Map"
-                src={mapEmbedUrl}
-                class="w-full h-[300px] border-0"
-                loading="lazy"
-                referrerpolicy="no-referrer-when-downgrade"
-              />
-            </noscript>
-          </div>
+          <iframe
+            title="Map"
+            src={mapEmbedUrl}
+            class="w-full h-[300px] border-0"
+            loading="lazy"
+            referrerpolicy="no-referrer-when-downgrade"
+          />
         ) : (
           <div class="w-full h-[300px] flex items-center justify-center">
             <span class="text-gray-500 text-sm">
@@ -113,22 +96,3 @@ const mapEmbedUrl =
     </div>
   )}
 </div>
-
-<script type="module" is:inline>
-  const container = document.querySelector('[data-map-container]');
-  if (container) {
-    const button = container.querySelector('[data-map-load]');
-    const src = container.getAttribute('data-map-src');
-    const load = () => {
-      if (!src) return;
-      const iframe = document.createElement('iframe');
-      iframe.title = 'Map';
-      iframe.src = src;
-      iframe.className = 'w-full h-[300px] border-0';
-      iframe.loading = 'lazy';
-      iframe.referrerPolicy = 'no-referrer-when-downgrade';
-      container.replaceWith(iframe);
-    };
-    if (button) button.addEventListener('click', load);
-  }
-</script>


### PR DESCRIPTION
### Motivation
- Ensure the homepage map is displayed immediately instead of being hidden behind a click-to-load prompt to match the requested behavior.
- Apply the change only to the web app homepage component so other apps are unaffected.

### Description
- Render the OpenStreetMap `<iframe>` directly when `mapEmbedUrl` is present by updating `apps/web/src/components/HomePageContent.astro`.
- Remove the lazy-load wrapper UI (the "Показать карту" button and placeholder) and delete the inline module script that injected the iframe on click.
- Preserve the iframe attributes `loading="lazy"` and `referrerpolicy` and keep the existing empty-state message when coordinates are missing or invalid.

### Testing
- Launched the dev server with `pnpm --filter web dev -- --host 0.0.0.0 --port 4321`, which started but the session was later interrupted.
- Attempted a Playwright screenshot of `http://localhost:4321`, which failed with `net::ERR_EMPTY_RESPONSE` so no screenshot was produced.
- No automated unit tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698484d1dd488327ae81cae0441ea95e)