### PR TITLE
Follow-up: reduce bare-domain redirect chain to address remaining 307 report

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,6 +1,17 @@
 {
   "redirects": [
     {
+      "source": "/",
+      "has": [
+        {
+          "type": "host",
+          "value": "pershyykrok.nl"
+        }
+      ],
+      "destination": "https://www.pershyykrok.nl/ua",
+      "permanent": true
+    },
+    {
       "source": "/(.*)",
       "has": [
         {

--- a/docs/google-indexing-remediation-plan.md
+++ b/docs/google-indexing-remediation-plan.md
@@ -44,6 +44,7 @@ Make Google consistently select `https://www.pershyykrok.nl` as canonical host a
 ## Rollout checklist
 
 - [x] Platform redirect configured as permanent from bare -> www (`apps/web/vercel.json`).
+- [x] Bare-domain root redirects directly to `https://www.pershyykrok.nl/ua` to avoid an extra `/` -> `/ua` hop.
 - [x] `siteSettings.seo.canonicalBaseUrl` defaults to `https://www.pershyykrok.nl` in Studio schema.
 - [ ] Sitemap/robots inspected in production and aligned to `www`.
 - [x] Internal hardcoded bare-domain links replaced (repo audit found no bare-domain app links).


### PR DESCRIPTION
### Motivation
- Reduce an extra redirect hop that led to a reported `307` by ensuring the bare-domain root request goes straight to the canonical host and locale (`/ua`).
- Complete the indexing-remediation canonical-host rollout so Google sees a consistent `www` host and fewer redirect hops.

### Description
- Add a root-specific permanent host redirect in `apps/web/vercel.json` that sends `https://pershyykrok.nl/` directly to `https://www.pershyykrok.nl/ua` while keeping the existing catch-all bare-domain → `www` redirect for other paths.
- Mark the root-hop reduction step as completed in `docs/google-indexing-remediation-plan.md` to reflect the updated rollout checklist.

### Testing
- Ran `pnpm --filter web build`, which completed successfully with no build errors.
- Verified the new redirect and doc changes by inspecting `apps/web/vercel.json` and `docs/google-indexing-remediation-plan.md` using `nl -ba`/`rg`, and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c49ae62088327817599a3511b667a)