### PR TITLE
Follow-up: Add GA4 gtag snippet to shared BaseLayout head

### DIFF
--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -119,17 +119,21 @@ const ogImageAlt = seo?.ogImageAlt?.[locale] ?? undefined;
       href="/fonts/pt-serif/pt-serif-v19-cyrillic_cyrillic-ext_latin_latin-ext-700.woff2"
       crossorigin
     />
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-PNWJLT84S6"></script>
-    <script is:inline>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        window.dataLayer.push(arguments);
-      }
-      gtag('js', new Date());
+    {!isPreview && (
+      <>
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-PNWJLT84S6"></script>
+        <script is:inline>
+          window.dataLayer = window.dataLayer || [];
+          function gtag() {
+            window.dataLayer.push(arguments);
+          }
+          gtag('js', new Date());
 
-      gtag('config', 'G-PNWJLT84S6');
-    </script>
+          gtag('config', 'G-PNWJLT84S6');
+        </script>
+      </>
+    )}
     <!-- Acumin Pro via Adobe Fonts: replace YOUR_ADOBE_KIT_ID with your kit ID from use.typekit.net -->
   </head>
   <body class="font-body text-body antialiased text-gray-900 flex flex-col min-h-screen">

--- a/apps/web/src/layouts/BaseLayout.astro
+++ b/apps/web/src/layouts/BaseLayout.astro
@@ -119,6 +119,17 @@ const ogImageAlt = seo?.ogImageAlt?.[locale] ?? undefined;
       href="/fonts/pt-serif/pt-serif-v19-cyrillic_cyrillic-ext_latin_latin-ext-700.woff2"
       crossorigin
     />
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-PNWJLT84S6"></script>
+    <script is:inline>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        window.dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+
+      gtag('config', 'G-PNWJLT84S6');
+    </script>
     <!-- Acumin Pro via Adobe Fonts: replace YOUR_ADOBE_KIT_ID with your kit ID from use.typekit.net -->
   </head>
   <body class="font-body text-body antialiased text-gray-900 flex flex-col min-h-screen">


### PR DESCRIPTION
### Motivation
- Ensure the GA4 tracking snippet is loaded on every page that uses the shared site layout by injecting the `gtag.js` snippet into the common `<head>`.

### Description
- Inserted the Google tag (`gtag.js`) script and an inline `gtag('config', 'G-PNWJLT84S6')` initialization into `apps/web/src/layouts/BaseLayout.astro` so the measurement ID is applied across pages.

### Testing
- Ran `pnpm -C apps/web build` which completed successfully, started the dev server with `pnpm -C apps/web dev` and captured a screenshot of `/ua` to verify rendering, and observed an external fetch to Google docs was blocked by the environment (HTTP 403) but did not affect the local build and render validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5ce8a8388832b8ca679a3b88fa648)