### PR TITLE
[codex] Add Sanity-managed AA resource links

### DIFF
--- a/apps/studio/schema.json
+++ b/apps/studio/schema.json
@@ -1398,6 +1398,80 @@
           }
         },
         "optional": true
+      },
+      "resourceLinksSection": {
+        "type": "objectAttribute",
+        "value": {
+          "type": "object",
+          "attributes": {
+            "sectionTitle": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "description": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "linkPrompt": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "string"
+              },
+              "optional": true
+            },
+            "items": {
+              "type": "objectAttribute",
+              "value": {
+                "type": "array",
+                "of": {
+                  "type": "object",
+                  "attributes": {
+                    "label": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      },
+                      "optional": true
+                    },
+                    "description": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      },
+                      "optional": true
+                    },
+                    "href": {
+                      "type": "objectAttribute",
+                      "value": {
+                        "type": "string"
+                      },
+                      "optional": true
+                    }
+                  },
+                  "rest": {
+                    "type": "object",
+                    "attributes": {
+                      "_key": {
+                        "type": "objectAttribute",
+                        "value": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "optional": true
+            }
+          }
+        },
+        "optional": true
       }
     }
   },

--- a/apps/studio/schemaTypes/documents/homePage.ts
+++ b/apps/studio/schemaTypes/documents/homePage.ts
@@ -45,6 +45,38 @@ export default defineType({
         { name: 'time', type: 'string', title: 'Time' },
         { name: 'languages', type: 'string', title: 'Languages' }
       ]
+    },
+    {
+      name: 'resourceLinksSection',
+      title: 'AA Resource Links',
+      type: 'object',
+      options: { collapsible: true, collapsed: false },
+      fields: [
+        { name: 'sectionTitle', type: 'string', title: 'Section Title' },
+        { name: 'description', type: 'text', title: 'Description', rows: 3 },
+        { name: 'linkPrompt', type: 'string', title: 'Link CTA' },
+        {
+          name: 'items',
+          type: 'array',
+          title: 'Links',
+          of: [
+            {
+              type: 'object',
+              preview: {
+                select: {
+                  title: 'label',
+                  subtitle: 'href',
+                },
+              },
+              fields: [
+                { name: 'label', type: 'string', title: 'Label' },
+                { name: 'description', type: 'text', title: 'Description', rows: 2 },
+                { name: 'href', type: 'url', title: 'URL' },
+              ],
+            },
+          ],
+        },
+      ],
     }
   ]
 })

--- a/apps/web/src/components/HomePageContent.astro
+++ b/apps/web/src/components/HomePageContent.astro
@@ -15,6 +15,63 @@ const t = {
   ru: { when: 'Когда', where: 'Где', languages: 'Языки', phone: 'Телефон', callUs: 'Позвоните нам' },
 }[locale];
 
+const resourceLinks = {
+  ua: {
+    title: 'Ресурси АА',
+    description: 'Перевірені сторінки, де можна знайти нашу групу, інші україномовні зустрічі та загальну інформацію про АА.',
+    action: 'Перейти',
+    items: [
+      {
+        label: 'Pershyy Krok в AA Netherlands',
+        description: 'Актуальна сторінка нашої групи в офіційному списку зустрічей AA Netherlands.',
+        href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
+      },
+      {
+        label: 'Україномовні групи за кордоном',
+        description: 'Список АА України з україномовними групами та контактами поза Україною.',
+        href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
+      },
+      {
+        label: 'A.A. Continental European Region',
+        description: 'Ресурси АА для англомовних груп у континентальній Європі.',
+        href: 'https://alcoholics-anonymous.eu/',
+      },
+      {
+        label: 'Alcoholics Anonymous',
+        description: 'Головний сайт Alcoholics Anonymous World Services з інформацією про програму АА.',
+        href: 'https://www.aa.org/',
+      },
+    ],
+  },
+  ru: {
+    title: 'Ресурсы АА',
+    description: 'Проверенные страницы, где можно найти нашу группу, другие украиноязычные встречи и общую информацию об АА.',
+    action: 'Перейти',
+    items: [
+      {
+        label: 'Pershyy Krok в AA Netherlands',
+        description: 'Актуальная страница нашей группы в официальном списке встреч AA Netherlands.',
+        href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
+      },
+      {
+        label: 'Украиноязычные группы за рубежом',
+        description: 'Список АА Украины с украиноязычными группами и контактами за пределами Украины.',
+        href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
+      },
+      {
+        label: 'A.A. Continental European Region',
+        description: 'Ресурсы АА для англоязычных групп в континентальной Европе.',
+        href: 'https://alcoholics-anonymous.eu/',
+      },
+      {
+        label: 'Alcoholics Anonymous',
+        description: 'Главный сайт Alcoholics Anonymous World Services с информацией о программе АА.',
+        href: 'https://www.aa.org/',
+      },
+    ],
+  },
+}[locale];
+
 const mapLocation = contact?.mapLocation ?? null;
 const hasMap = mapLocation && mapLocation.lat != null && mapLocation.lng != null;
 const mapBbox = hasMap
@@ -95,4 +152,28 @@ const mapEmbedUrl =
       </div>
     </div>
   )}
+
+  <section class="mt-12 border-t border-gray-200 pt-8" aria-labelledby="aa-resource-links-title">
+    <div class="max-w-3xl">
+      <h2 id="aa-resource-links-title" class="text-lg font-semibold">{resourceLinks.title}</h2>
+      <p class="mt-2 text-gray-700">{resourceLinks.description}</p>
+    </div>
+
+    <div class="mt-5 grid grid-cols-1 md:grid-cols-2 gap-4">
+      {resourceLinks.items.map((item) => (
+        <a
+          href={item.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="group block rounded-md border border-gray-200 bg-white p-4 transition-colors hover:border-[#1371AF] focus:outline-none focus:ring-2 focus:ring-[#1371AF] focus:ring-offset-2"
+        >
+          <span class="block font-semibold text-gray-950">{item.label}</span>
+          <span class="mt-2 block text-sm leading-6 text-gray-700">{item.description}</span>
+          <span class="mt-3 inline-flex text-sm font-semibold text-[#0B4A78] group-hover:underline">
+            {resourceLinks.action}
+          </span>
+        </a>
+      ))}
+    </div>
+  </section>
 </div>

--- a/apps/web/src/components/HomePageContent.astro
+++ b/apps/web/src/components/HomePageContent.astro
@@ -15,62 +15,11 @@ const t = {
   ru: { when: 'Когда', where: 'Где', languages: 'Языки', phone: 'Телефон', callUs: 'Позвоните нам' },
 }[locale];
 
-const resourceLinks = {
-  ua: {
-    title: 'Ресурси АА',
-    description: 'Перевірені сторінки, де можна знайти нашу групу, інші україномовні зустрічі та загальну інформацію про АА.',
-    action: 'Перейти',
-    items: [
-      {
-        label: 'Pershyy Krok в AA Netherlands',
-        description: 'Актуальна сторінка нашої групи в офіційному списку зустрічей AA Netherlands.',
-        href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
-      },
-      {
-        label: 'Україномовні групи за кордоном',
-        description: 'Список АА України з україномовними групами та контактами поза Україною.',
-        href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
-      },
-      {
-        label: 'A.A. Continental European Region',
-        description: 'Ресурси АА для англомовних груп у континентальній Європі.',
-        href: 'https://alcoholics-anonymous.eu/',
-      },
-      {
-        label: 'Alcoholics Anonymous',
-        description: 'Головний сайт Alcoholics Anonymous World Services з інформацією про програму АА.',
-        href: 'https://www.aa.org/',
-      },
-    ],
-  },
-  ru: {
-    title: 'Ресурсы АА',
-    description: 'Проверенные страницы, где можно найти нашу группу, другие украиноязычные встречи и общую информацию об АА.',
-    action: 'Перейти',
-    items: [
-      {
-        label: 'Pershyy Krok в AA Netherlands',
-        description: 'Актуальная страница нашей группы в официальном списке встреч AA Netherlands.',
-        href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
-      },
-      {
-        label: 'Украиноязычные группы за рубежом',
-        description: 'Список АА Украины с украиноязычными группами и контактами за пределами Украины.',
-        href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
-      },
-      {
-        label: 'A.A. Continental European Region',
-        description: 'Ресурсы АА для англоязычных групп в континентальной Европе.',
-        href: 'https://alcoholics-anonymous.eu/',
-      },
-      {
-        label: 'Alcoholics Anonymous',
-        description: 'Главный сайт Alcoholics Anonymous World Services с информацией о программе АА.',
-        href: 'https://www.aa.org/',
-      },
-    ],
-  },
-}[locale];
+const resourceLinksSection = data.resourceLinksSection;
+const resourceItems =
+  resourceLinksSection?.items?.filter((item) => item?.label && item?.href) ?? [];
+const showResourceLinks =
+  Boolean(resourceLinksSection?.sectionTitle) && resourceItems.length > 0;
 
 const mapLocation = contact?.mapLocation ?? null;
 const hasMap = mapLocation && mapLocation.lat != null && mapLocation.lng != null;
@@ -153,27 +102,35 @@ const mapEmbedUrl =
     </div>
   )}
 
-  <section class="mt-12 border-t border-gray-200 pt-8" aria-labelledby="aa-resource-links-title">
-    <div class="max-w-3xl">
-      <h2 id="aa-resource-links-title" class="text-lg font-semibold">{resourceLinks.title}</h2>
-      <p class="mt-2 text-gray-700">{resourceLinks.description}</p>
-    </div>
+  {showResourceLinks && (
+    <section class="mt-12 border-t border-gray-200 pt-8" aria-labelledby="aa-resource-links-title">
+      <div class="max-w-3xl">
+        <h2 id="aa-resource-links-title" class="text-lg font-semibold">{resourceLinksSection!.sectionTitle}</h2>
+        {resourceLinksSection!.description && (
+          <p class="mt-2 text-gray-700">{resourceLinksSection!.description}</p>
+        )}
+      </div>
 
-    <div class="mt-5 grid grid-cols-1 md:grid-cols-2 gap-4">
-      {resourceLinks.items.map((item) => (
-        <a
-          href={item.href}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="group block rounded-md border border-gray-200 bg-white p-4 transition-colors hover:border-[#1371AF] focus:outline-none focus:ring-2 focus:ring-[#1371AF] focus:ring-offset-2"
-        >
-          <span class="block font-semibold text-gray-950">{item.label}</span>
-          <span class="mt-2 block text-sm leading-6 text-gray-700">{item.description}</span>
-          <span class="mt-3 inline-flex text-sm font-semibold text-[#0B4A78] group-hover:underline">
-            {resourceLinks.action}
-          </span>
-        </a>
-      ))}
-    </div>
-  </section>
+      <div class="mt-5 grid grid-cols-1 md:grid-cols-2 gap-4">
+        {resourceItems.map((item) => (
+          <a
+            href={item.href!}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="group block rounded-md border border-gray-200 bg-white p-4 transition-colors hover:border-[#1371AF] focus:outline-none focus:ring-2 focus:ring-[#1371AF] focus:ring-offset-2"
+          >
+            <span class="block font-semibold text-gray-950">{item.label}</span>
+            {item.description && (
+              <span class="mt-2 block text-sm leading-6 text-gray-700">{item.description}</span>
+            )}
+            {resourceLinksSection!.linkPrompt && (
+              <span class="mt-3 inline-flex text-sm font-semibold text-[#0B4A78] group-hover:underline">
+                {resourceLinksSection!.linkPrompt}
+              </span>
+            )}
+          </a>
+        ))}
+      </div>
+    </section>
+  )}
 </div>

--- a/apps/web/src/queries.ts
+++ b/apps/web/src/queries.ts
@@ -31,6 +31,16 @@ export const homePageQuery = groq`*[_type == "homePage" && language == $locale][
     sectionTitle,
     time,
     languages
+  },
+  resourceLinksSection{
+    sectionTitle,
+    description,
+    linkPrompt,
+    items[]{
+      label,
+      description,
+      href
+    }
   }
 }`;
 

--- a/apps/web/src/sanity-types.ts
+++ b/apps/web/src/sanity-types.ts
@@ -244,6 +244,17 @@ export type HomePage = {
     time?: string;
     languages?: string;
   };
+  resourceLinksSection?: {
+    sectionTitle?: string;
+    description?: string;
+    linkPrompt?: string;
+    items?: Array<{
+      label?: string;
+      description?: string;
+      href?: string;
+      _key: string;
+    }>;
+  };
 };
 
 export type SanityImagePaletteSwatch = {
@@ -470,7 +481,7 @@ export type SiteSettingsQueryResult =
 
 // Source: ../web/src/queries.ts
 // Variable: homePageQuery
-// Query: *[_type == "homePage" && language == $locale][0]{  title,  introText,  language,  meetingSection{    sectionTitle,    time,    languages  }}
+// Query: *[_type == "homePage" && language == $locale][0]{  title,  introText,  language,  meetingSection{    sectionTitle,    time,    languages  },  resourceLinksSection{    sectionTitle,    description,    linkPrompt,    items[]{      label,      description,      href    }  }}
 export type HomePageQueryResult = {
   title: string | null;
   introText: BlockContent | null;
@@ -479,6 +490,16 @@ export type HomePageQueryResult = {
     sectionTitle: string | null;
     time: string | null;
     languages: string | null;
+  } | null;
+  resourceLinksSection: {
+    sectionTitle: string | null;
+    description: string | null;
+    linkPrompt: string | null;
+    items: Array<{
+      label: string | null;
+      description: string | null;
+      href: string | null;
+    }> | null;
   } | null;
 } | null;
 
@@ -642,7 +663,7 @@ import "@sanity/client";
 declare module "@sanity/client" {
   interface SanityQueries {
     '*[_id == "siteSettings"][0]{\n  logo,\n  mainMenuRu[]{\n    label,\n    "link": link->{ _type, "slug": slug.current }\n  },\n  mainMenuUa[]{\n    label,\n    "link": link->{ _type, "slug": slug.current }\n  },\n  footerText,\n  "contact": coalesce(contact, footerContact),\n  seo{\n    title,\n    description,\n    ogImage,\n    ogImageAlt,\n    canonicalBaseUrl\n  }\n}': SiteSettingsQueryResult;
-    '*[_type == "homePage" && language == $locale][0]{\n  title,\n  introText,\n  language,\n  meetingSection{\n    sectionTitle,\n    time,\n    languages\n  }\n}': HomePageQueryResult;
+    '*[_type == "homePage" && language == $locale][0]{\n  title,\n  introText,\n  language,\n  meetingSection{\n    sectionTitle,\n    time,\n    languages\n  },\n  resourceLinksSection{\n    sectionTitle,\n    description,\n    linkPrompt,\n    items[]{\n      label,\n      description,\n      href\n    }\n  }\n}': HomePageQueryResult;
     '*[_type == "page" && language == $locale && slug.current == $slug][0]{\n  title,\n  body,\n  slug\n}': PageBySlugQueryResult;
     '*[_type == "faq" && language == $locale && slug.current == $slug][0]{\n  title,\n  intro,\n  items[]{\n    question,\n    answer\n  },\n  slug\n}': FaqBySlugQueryResult;
     '*[_type == "selfTest" && language == $locale && slug.current == $slug][0]{\n  title,\n  intro,\n  questions[]{\n    text\n  },\n  resultCopy,\n  slug\n}': SelfTestBySlugQueryResult;

--- a/scripts/one-off/seed-homepage-resource-links.mjs
+++ b/scripts/one-off/seed-homepage-resource-links.mjs
@@ -1,11 +1,13 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import {createRequire} from 'node:module'
+import {fileURLToPath} from 'node:url'
 
-const requireFromWeb = createRequire(new URL('../apps/web/package.json', import.meta.url))
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const requireFromWeb = createRequire(new URL('../../apps/web/package.json', import.meta.url))
 const {createClient} = requireFromWeb('@sanity/client')
 
-const envPath = path.resolve(process.cwd(), '.env.local')
+const envPath = path.join(repoRoot, '.env.local')
 const env = {...process.env}
 
 if (fs.existsSync(envPath)) {
@@ -45,28 +47,24 @@ const resourceLinksByLanguage = {
     linkPrompt: 'Перейти',
     items: [
       {
-        _type: 'object',
         _key: 'aa-netherlands',
         label: 'Pershyy Krok в AA Netherlands',
         description: 'Актуальна сторінка нашої групи в офіційному списку зустрічей AA Netherlands.',
         href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
       },
       {
-        _type: 'object',
         _key: 'aa-ukraine-abroad',
         label: 'Україномовні групи за кордоном',
         description: 'Список АА України з україномовними групами та контактами поза Україною.',
         href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
       },
       {
-        _type: 'object',
         _key: 'aa-continental-europe',
         label: 'A.A. Continental European Region',
         description: 'Ресурси АА для англомовних груп у континентальній Європі.',
         href: 'https://alcoholics-anonymous.eu/',
       },
       {
-        _type: 'object',
         _key: 'aa-world-services',
         label: 'Alcoholics Anonymous',
         description: 'Головний сайт Alcoholics Anonymous World Services з інформацією про програму АА.',
@@ -81,28 +79,24 @@ const resourceLinksByLanguage = {
     linkPrompt: 'Перейти',
     items: [
       {
-        _type: 'object',
         _key: 'aa-netherlands',
         label: 'Pershyy Krok в AA Netherlands',
         description: 'Актуальная страница нашей группы в официальном списке встреч AA Netherlands.',
         href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
       },
       {
-        _type: 'object',
         _key: 'aa-ukraine-abroad',
         label: 'Украиноязычные группы за рубежом',
         description: 'Список АА Украины с украиноязычными группами и контактами за пределами Украины.',
         href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
       },
       {
-        _type: 'object',
         _key: 'aa-continental-europe',
         label: 'A.A. Continental European Region',
         description: 'Ресурсы АА для англоязычных групп в континентальной Европе.',
         href: 'https://alcoholics-anonymous.eu/',
       },
       {
-        _type: 'object',
         _key: 'aa-world-services',
         label: 'Alcoholics Anonymous',
         description: 'Главный сайт Alcoholics Anonymous World Services с информацией о программе АА.',

--- a/scripts/seed-homepage-resource-links.mjs
+++ b/scripts/seed-homepage-resource-links.mjs
@@ -1,0 +1,134 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import {createRequire} from 'node:module'
+
+const requireFromWeb = createRequire(new URL('../apps/web/package.json', import.meta.url))
+const {createClient} = requireFromWeb('@sanity/client')
+
+const envPath = path.resolve(process.cwd(), '.env.local')
+const env = {...process.env}
+
+if (fs.existsSync(envPath)) {
+  const envText = fs.readFileSync(envPath, 'utf8')
+  for (const line of envText.split(/\r?\n/)) {
+    if (!line || line.trim().startsWith('#')) continue
+    const idx = line.indexOf('=')
+    if (idx === -1) continue
+    const key = line.slice(0, idx).trim()
+    let val = line.slice(idx + 1).trim()
+    if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+      val = val.slice(1, -1)
+    }
+    env[key] = val
+  }
+}
+
+const token = env.SANITY_API_WRITE_TOKEN
+if (!token) {
+  console.error('SANITY_API_WRITE_TOKEN not found in the environment or repo-root .env.local')
+  process.exit(1)
+}
+
+const client = createClient({
+  projectId: 'n1ug74wc',
+  dataset: 'production',
+  apiVersion: '2024-02-01',
+  useCdn: false,
+  token,
+})
+
+const resourceLinksByLanguage = {
+  ua: {
+    sectionTitle: 'Ресурси АА',
+    description:
+      'Перевірені сторінки, де можна знайти нашу групу, інші україномовні зустрічі та загальну інформацію про АА.',
+    linkPrompt: 'Перейти',
+    items: [
+      {
+        _type: 'object',
+        _key: 'aa-netherlands',
+        label: 'Pershyy Krok в AA Netherlands',
+        description: 'Актуальна сторінка нашої групи в офіційному списку зустрічей AA Netherlands.',
+        href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
+      },
+      {
+        _type: 'object',
+        _key: 'aa-ukraine-abroad',
+        label: 'Україномовні групи за кордоном',
+        description: 'Список АА України з україномовними групами та контактами поза Україною.',
+        href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
+      },
+      {
+        _type: 'object',
+        _key: 'aa-continental-europe',
+        label: 'A.A. Continental European Region',
+        description: 'Ресурси АА для англомовних груп у континентальній Європі.',
+        href: 'https://alcoholics-anonymous.eu/',
+      },
+      {
+        _type: 'object',
+        _key: 'aa-world-services',
+        label: 'Alcoholics Anonymous',
+        description: 'Головний сайт Alcoholics Anonymous World Services з інформацією про програму АА.',
+        href: 'https://www.aa.org/',
+      },
+    ],
+  },
+  ru: {
+    sectionTitle: 'Ресурсы АА',
+    description:
+      'Проверенные страницы, где можно найти нашу группу, другие украиноязычные встречи и общую информацию об АА.',
+    linkPrompt: 'Перейти',
+    items: [
+      {
+        _type: 'object',
+        _key: 'aa-netherlands',
+        label: 'Pershyy Krok в AA Netherlands',
+        description: 'Актуальная страница нашей группы в официальном списке встреч AA Netherlands.',
+        href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
+      },
+      {
+        _type: 'object',
+        _key: 'aa-ukraine-abroad',
+        label: 'Украиноязычные группы за рубежом',
+        description: 'Список АА Украины с украиноязычными группами и контактами за пределами Украины.',
+        href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
+      },
+      {
+        _type: 'object',
+        _key: 'aa-continental-europe',
+        label: 'A.A. Continental European Region',
+        description: 'Ресурсы АА для англоязычных групп в континентальной Европе.',
+        href: 'https://alcoholics-anonymous.eu/',
+      },
+      {
+        _type: 'object',
+        _key: 'aa-world-services',
+        label: 'Alcoholics Anonymous',
+        description: 'Главный сайт Alcoholics Anonymous World Services с информацией о программе АА.',
+        href: 'https://www.aa.org/',
+      },
+    ],
+  },
+}
+
+const main = async () => {
+  for (const [language, resourceLinksSection] of Object.entries(resourceLinksByLanguage)) {
+    const homePage = await client.fetch('*[_type == "homePage" && language == $language][0]{_id}', {
+      language,
+    })
+
+    if (!homePage?._id) {
+      console.warn(`Skipped ${language}: no homePage document found`)
+      continue
+    }
+
+    await client.patch(homePage._id).set({resourceLinksSection}).commit()
+    console.log(`Updated ${language} homepage resource links: ${homePage._id}`)
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Motivation

This site represents the Pershyy Krok AA group, and it is useful for both visitors and search engines to see clear outbound context to established AA resources. The links help visitors verify the group through AA Netherlands, find Ukrainian-speaking AA groups abroad, understand the Continental European AA service context, and reach the main Alcoholics Anonymous World Services site.

Following review feedback, the resource copy and URLs now live in Sanity rather than in the Astro component, so editors can maintain typos, translations, CTA text, and changed external URLs without a code change.

## What Changed

- Added `resourceLinksSection` to the Sanity `homePage` document schema, co-located with the existing homepage intro and meeting section content.
- Regenerated `apps/studio/schema.json` and `apps/web/src/sanity-types.ts` from the updated schema/query shape.
- Extended `homePageQuery` to fetch `resourceLinksSection` fields:
  - section title
  - description
  - link CTA text
  - link label, description, and URL items
- Updated `HomePageContent.astro` to render the existing responsive resource-card UI from `data.resourceLinksSection` only when CMS content exists.
- Removed the runtime hardcoded translated strings and external URLs from the component.
- Added `scripts/one-off/seed-homepage-resource-links.mjs` to populate the current Ukrainian and Russian homepage documents with the initial four AA resource links using a Sanity write token.
- Polished the seed script after review: moved it under `scripts/one-off/`, removed superfluous `_type: 'object'` values, and made repo-root `.env.local` lookup independent of `process.cwd()`.

## Initial Resource Links

The production Sanity `ua` and `ru` homepage documents have now been populated with these four links:

- Pershyy Krok in AA Netherlands: `https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/`
- AA Ukraine: Ukrainian-speaking groups abroad: `https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/`
- A.A. Continental European Region: `https://alcoholics-anonymous.eu/`
- Alcoholics Anonymous World Services: `https://www.aa.org/`

## Validation

- Ran `CI=true pnpm --filter studio codemod` successfully to regenerate schema/type artifacts.
- Ran `CI=true pnpm --filter web build` successfully.
- Ran `CI=true pnpm --filter studio build` successfully.
- Ran `git diff --check` successfully.
- Ran `node --check scripts/one-off/seed-homepage-resource-links.mjs` successfully.
- Ran `scripts/one-off/seed-homepage-resource-links.mjs` from outside the repo with the local Sanity CLI auth token exported as `SANITY_API_WRITE_TOKEN`, verifying the script no longer depends on `process.cwd()`.
- Verified the public Sanity dataset: both `ru` and `ua` `homePage` documents have `resourceLinksSection` with 4 items, and the seeded link items no longer store `_type` noise.
- Smoke-tested `/ua/` and `/ru/` locally in the browser after seeding; both pages render the resource section with the expected four URLs and no horizontal overflow.

## Existing Build Notes

The build still reports pre-existing hints about an unused generated Sanity helper type, the Google Tag Manager script hint, router warnings for dynamic pages, and local Node 25 versus Vercel Node 22. None are introduced by this PR.