### PR TITLE
Improve AI workflow guidance and Sanity deploy safety

### DIFF
--- a/.github/ISSUE_TEMPLATE/ai-task.md
+++ b/.github/ISSUE_TEMPLATE/ai-task.md
@@ -1,0 +1,28 @@
+---
+name: AI task
+about: A scoped task for Codex, Claude, Antigravity, or another AI coding agent
+title: ""
+labels: codex
+assignees: ""
+---
+
+## Goal
+
+
+## Scope
+
+-
+
+## Constraints
+
+- Do not change secrets or external service settings.
+- Do not mutate production Sanity content unless explicitly requested.
+- Avoid unrelated refactors.
+
+## Validation
+
+-
+
+## Out Of Scope
+
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+-
+
+## Validation
+
+- [ ] Ran the relevant build/check commands, or explained why not.
+- [ ] Updated generated Sanity schema/types when schema or query shape changed.
+- [ ] Checked production-sensitive effects such as SEO, redirects, secrets, and Sanity content.
+
+## Notes
+
+-

--- a/.github/workflows/deploy-sanity-schema.yml
+++ b/.github/workflows/deploy-sanity-schema.yml
@@ -32,6 +32,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check Sanity schema deploy token
+        run: |
+          if [ -z "${SANITY_AUTH_TOKEN:-}" ]; then
+            echo "::error title=Missing SANITY_AUTH_TOKEN::Add a repository secret named SANITY_AUTH_TOKEN with Sanity schema deploy access for project n1ug74wc."
+            exit 1
+          fi
+          echo "SANITY_AUTH_TOKEN is set. It must include the Sanity grant sanity.project/deployStudio for project n1ug74wc."
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+
       - name: Deploy Sanity schema
         run: pnpm --filter studio exec sanity schema deploy
         env:

--- a/.github/workflows/deploy-sanity-schema.yml
+++ b/.github/workflows/deploy-sanity-schema.yml
@@ -32,7 +32,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check generated schema diff
+        id: schema-diff
+        run: |
+          pnpm --filter studio extract
+          if git diff --quiet -- apps/studio/schema.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Generated schema is unchanged; schema deployment will be skipped."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Generated schema changed; schema deployment is required."
+          fi
+
       - name: Check Sanity schema deploy token
+        if: github.event_name == 'workflow_dispatch' || steps.schema-diff.outputs.changed == 'true'
         run: |
           if [ -z "${SANITY_AUTH_TOKEN:-}" ]; then
             echo "::error title=Missing SANITY_AUTH_TOKEN::Add a repository secret named SANITY_AUTH_TOKEN with Sanity schema deploy access for project n1ug74wc."
@@ -42,7 +55,12 @@ jobs:
         env:
           SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
 
+      - name: Skip unchanged schema deploy
+        if: github.event_name != 'workflow_dispatch' && steps.schema-diff.outputs.changed != 'true'
+        run: echo "Schema source changed without changing generated schema; skipping deploy."
+
       - name: Deploy Sanity schema
+        if: github.event_name == 'workflow_dispatch' || steps.schema-diff.outputs.changed == 'true'
         run: pnpm --filter studio exec sanity schema deploy
         env:
           SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}

--- a/.github/workflows/deploy-sanity-schema.yml
+++ b/.github/workflows/deploy-sanity-schema.yml
@@ -36,12 +36,30 @@ jobs:
         id: schema-diff
         run: |
           pnpm --filter studio extract
-          if git diff --quiet -- apps/studio/schema.json; then
+
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Manual run requested; schema deployment is required."
+            exit 0
+          fi
+
+          base_sha="${{ github.event.before }}"
+          if [ -z "$base_sha" ] || [ "$base_sha" = "0000000000000000000000000000000000000000" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "Previous main revision is unavailable; schema deployment is required."
+            exit 0
+          fi
+
+          if ! git cat-file -e "$base_sha^{commit}" 2>/dev/null; then
+            git fetch --no-tags --depth=1 origin "$base_sha"
+          fi
+
+          if git diff --quiet "$base_sha" -- apps/studio/schema.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Generated schema is unchanged; schema deployment will be skipped."
+            echo "Generated schema is unchanged from the previous main revision; schema deployment will be skipped."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Generated schema changed; schema deployment is required."
+            echo "Generated schema changed from the previous main revision; schema deployment is required."
           fi
 
       - name: Check Sanity schema deploy token

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# Agent Guide
+
+This repository is production-facing. Treat changes as if they can affect a live public website, Sanity editors, and SEO.
+Use this file as the shared source of truth for Codex, Claude, Antigravity, Copilot, and other AI-assisted development tools.
+
+## Project Map
+
+- `apps/web`: Astro website, Tailwind, Sanity queries, locale routes (`/ua`, `/ru`).
+- `apps/studio`: Sanity Studio schemas, preview/deploy actions, editor tooling.
+- `docs`: operational notes and remediation plans.
+- `.github/workflows`: CI/deploy automation.
+- `scripts/one-off`: one-time or recovery scripts; do not run against production without explicit intent.
+
+## Operating Rules
+
+- Prefer small, reviewable PRs with one clear purpose.
+- Do not change secrets, GitHub repository settings, Vercel settings, or Sanity project settings from code.
+- Do not print tokens. Use environment variables and redact values in logs or comments.
+- Do not mutate Sanity production content unless the task explicitly asks for it.
+- If a fix requires owner credentials or external console access, document the exact action instead of guessing.
+- Keep Ukrainian/Russian behavior symmetrical unless the request is explicitly locale-specific.
+- Keep generated files in sync when schema or query changes require them.
+
+## Validation
+
+Use the narrowest meaningful checks for the change:
+
+- Web changes: `CI=true pnpm --filter web build`
+- Studio/schema changes: `CI=true pnpm --filter studio build`
+- Schema/query/type changes: `CI=true pnpm --filter studio codemod`
+- Formatting/whitespace: `git diff --check`
+- One-off scripts: `node --check path/to/script.mjs`
+
+Note pre-existing warnings separately from new failures.
+
+## Sanity And Content
+
+- Schema source lives under `apps/studio/schemaTypes`.
+- Web GROQ queries live in `apps/web/src/queries.ts`.
+- Sanity typegen writes to `apps/web/src/sanity-types.ts`.
+- Public content is managed in Sanity. Avoid hardcoding editor-owned copy or URLs in Astro components.
+- Production content changes should be idempotent and documented, preferably in `scripts/one-off`.
+
+## GitHub And AI Workflow
+
+- Keep AI task prompts in GitHub issues or PR comments, not scattered across chat threads.
+- Use `@codex` comments only with clear scope, constraints, validation commands, and out-of-scope boundaries.
+- If an AI connector says it created a PR, verify that a real GitHub PR and remote branch exist.
+- If an AI connector cannot push, a human/local agent may reimplement the small change and open the PR.
+- Do not ping maintainers for low-priority maintenance unless a credential or product decision is required.
+
+## PR Expectations
+
+- Explain why the change matters.
+- List changed surfaces: web, Studio, Sanity content, CI, docs, or scripts.
+- Include validation commands and results.
+- Call out any required external action, such as updating `SANITY_AUTH_TOKEN`.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This repo includes a Studio action that opens a draft preview using a server-ren
 
 ### Studio env vars (apps/studio)
 
-- `SANITY_STUDIO_PREVIEW_URL`: Base URL of the website (e.g. `https://pershyykrok.nl`).
+- `SANITY_STUDIO_PREVIEW_URL`: Base URL of the website (e.g. `https://www.pershyykrok.nl`).
 - `SANITY_STUDIO_PREVIEW_SECRET`: Must match `SANITY_PREVIEW_SECRET`.
 - `SANITY_STUDIO_VERCEL_DEPLOY_HOOK`: Vercel Deploy Hook URL for manual deploys from Studio.
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,15 @@ This repo includes a GitHub Action that deploys the Sanity schema **only when sc
 - Workflow: `.github/workflows/deploy-sanity-schema.yml`
 - Trigger: `apps/studio/schemaTypes/**` and `apps/studio/sanity.config.ts`
 - Manual run: available via **Actions → Deploy Sanity Schema → Run workflow** (this is what `workflow_dispatch` enables).
+- More detail: `docs/sanity-schema-deploy.md`
 
 ### Required GitHub secret
 
 Add a repository secret named `SANITY_AUTH_TOKEN` with a **Developer** token (Editor is not sufficient for schema deploy).
 
 Create it in Sanity: Project → **API** → **Tokens** → **New token** → **Role: Developer**.
+
+The token must include the Sanity grant `sanity.project/deployStudio` for project `n1ug74wc`.
 
 ## Deploy on Vercel (website + studio)
 
@@ -113,4 +116,3 @@ Optional: if your Sanity project needs env vars (e.g. for CORS or a plugin), add
 
 - **Website**: Use the Vercel URL (e.g. `pershyykrok-web.vercel.app`).
 - **Studio**: Use the Studio project URL (e.g. `pershyykrok-studio.vercel.app`). In [sanity.io/manage](https://sanity.io/manage), add this URL to your project’s **API → CORS origins** (and **Hosts** if you use it) so the Studio can talk to Sanity.
-

--- a/TODO.md
+++ b/TODO.md
@@ -23,4 +23,4 @@ Copy of the development plan todos so collaborators can see what is done and wha
 - [x] Add a deploy feature (Studio → Vercel) to trigger or link to Vercel deploy from Studio
 - [ ] Add missing translations
 - [ ] Evaluate performance and SEO
-- [ ] Refactor slug uniqueness helper into shared module once Studio hot-reload is stable
+- [x] Refactor slug uniqueness helper into shared module once Studio hot-reload is stable

--- a/apps/studio/schemaTypes/documents/faq.ts
+++ b/apps/studio/schemaTypes/documents/faq.ts
@@ -1,35 +1,13 @@
-import { defineType, type SlugIsUniqueFn } from 'sanity'
-
-const isUniqueSlugByLang: SlugIsUniqueFn = async (slug, context) => {
-  const { document, getClient } = context
-  const currentId = document?._id?.replace(/^drafts\./, '')
-  const draftId = currentId ? `drafts.${currentId}` : undefined
-  const language = (document as { language?: string } | undefined)?.language
-
-  if (!slug?.current || !language) return true
-
-  const client = getClient({ apiVersion: '2023-10-16' })
-  const query =
-    '*[_type == $type && slug.current == $slug && language == $language && !(_id in [$id, $draftId])][0]._id'
-  const params = {
-    type: document?._type,
-    slug: slug.current,
-    language,
-    id: currentId,
-    draftId,
-  }
-
-  const existingId = await client.fetch<string | null>(query, params)
-  return !existingId
-}
+import {defineType} from 'sanity'
+import {isUniqueSlugByLang} from '../utils/isUniqueSlugByLang'
 
 export default defineType({
   name: 'faq',
   title: 'FAQ',
   type: 'document',
   preview: {
-    select: { title: 'title', slug: 'slug.current', language: 'language' },
-    prepare({ title, slug, language }) {
+    select: {title: 'title', slug: 'slug.current', language: 'language'},
+    prepare({title, slug, language}) {
       const parts = [language, slug].filter(Boolean)
       return {
         title: title ?? 'Untitled',
@@ -44,11 +22,11 @@ export default defineType({
       readOnly: true,
       hidden: true,
     },
-    { name: 'title', type: 'string', title: 'Page Title' },
+    {name: 'title', type: 'string', title: 'Page Title'},
     {
       name: 'slug',
       type: 'slug',
-      options: { source: 'title', isUnique: isUniqueSlugByLang },
+      options: {source: 'title', isUnique: isUniqueSlugByLang},
       validation: (Rule) => Rule.required(),
     },
     {
@@ -65,11 +43,11 @@ export default defineType({
           type: 'object',
           title: 'FAQ Item',
           fields: [
-            { name: 'question', type: 'string', title: 'Question' },
-            { name: 'answer', type: 'blockContent', title: 'Answer' },
+            {name: 'question', type: 'string', title: 'Question'},
+            {name: 'answer', type: 'blockContent', title: 'Answer'},
           ],
           preview: {
-            select: { title: 'question' },
+            select: {title: 'question'},
           },
         },
       ],

--- a/apps/studio/schemaTypes/documents/page.ts
+++ b/apps/studio/schemaTypes/documents/page.ts
@@ -1,35 +1,13 @@
-import { defineType, type SlugIsUniqueFn } from 'sanity'
-
-const isUniqueSlugByLang: SlugIsUniqueFn = async (slug, context) => {
-  const { document, getClient } = context
-  const currentId = document?._id?.replace(/^drafts\./, '')
-  const draftId = currentId ? `drafts.${currentId}` : undefined
-  const language = (document as { language?: string } | undefined)?.language
-
-  if (!slug?.current || !language) return true
-
-  const client = getClient({ apiVersion: '2023-10-16' })
-  const query =
-    '*[_type == $type && slug.current == $slug && language == $language && !(_id in [$id, $draftId])][0]._id'
-  const params = {
-    type: document?._type,
-    slug: slug.current,
-    language,
-    id: currentId,
-    draftId,
-  }
-
-  const existingId = await client.fetch<string | null>(query, params)
-  return !existingId
-}
+import {defineType} from 'sanity'
+import {isUniqueSlugByLang} from '../utils/isUniqueSlugByLang'
 
 export default defineType({
   name: 'page',
   title: 'Generic Page',
   type: 'document',
   preview: {
-    select: { title: 'title', slug: 'slug.current', language: 'language' },
-    prepare({ title, slug, language }) {
+    select: {title: 'title', slug: 'slug.current', language: 'language'},
+    prepare({title, slug, language}) {
       const parts = [language, slug].filter(Boolean)
       return {
         title: title ?? 'Untitled',
@@ -44,11 +22,11 @@ export default defineType({
       readOnly: true,
       hidden: true, // Optional: hides it from the UI so it doesn't clutter the form
     },
-    { name: 'title', type: 'string', title: 'Page Title' },
+    {name: 'title', type: 'string', title: 'Page Title'},
     {
       name: 'slug',
       type: 'slug',
-      options: { source: 'title', isUnique: isUniqueSlugByLang },
+      options: {source: 'title', isUnique: isUniqueSlugByLang},
       validation: (Rule) => Rule.required(),
     },
     {

--- a/apps/studio/schemaTypes/documents/selfTest.ts
+++ b/apps/studio/schemaTypes/documents/selfTest.ts
@@ -1,35 +1,13 @@
-import { defineType, type SlugIsUniqueFn } from 'sanity'
-
-const isUniqueSlugByLang: SlugIsUniqueFn = async (slug, context) => {
-  const { document, getClient } = context
-  const currentId = document?._id?.replace(/^drafts\./, '')
-  const draftId = currentId ? `drafts.${currentId}` : undefined
-  const language = (document as { language?: string } | undefined)?.language
-
-  if (!slug?.current || !language) return true
-
-  const client = getClient({ apiVersion: '2023-10-16' })
-  const query =
-    '*[_type == $type && slug.current == $slug && language == $language && !(_id in [$id, $draftId])][0]._id'
-  const params = {
-    type: document?._type,
-    slug: slug.current,
-    language,
-    id: currentId,
-    draftId,
-  }
-
-  const existingId = await client.fetch<string | null>(query, params)
-  return !existingId
-}
+import {defineType} from 'sanity'
+import {isUniqueSlugByLang} from '../utils/isUniqueSlugByLang'
 
 export default defineType({
   name: 'selfTest',
   title: 'Self-Assessment',
   type: 'document',
   preview: {
-    select: { title: 'title', slug: 'slug.current', language: 'language' },
-    prepare({ title, slug, language }) {
+    select: {title: 'title', slug: 'slug.current', language: 'language'},
+    prepare({title, slug, language}) {
       const parts = [language, slug].filter(Boolean)
       return {
         title: title ?? 'Untitled',
@@ -44,11 +22,11 @@ export default defineType({
       readOnly: true,
       hidden: true,
     },
-    { name: 'title', type: 'string', title: 'Page Title' },
+    {name: 'title', type: 'string', title: 'Page Title'},
     {
       name: 'slug',
       type: 'slug',
-      options: { source: 'title', isUnique: isUniqueSlugByLang },
+      options: {source: 'title', isUnique: isUniqueSlugByLang},
       validation: (Rule) => Rule.required(),
     },
     {
@@ -64,9 +42,9 @@ export default defineType({
         {
           type: 'object',
           title: 'Question',
-          fields: [{ name: 'text', type: 'string', title: 'Text' }],
+          fields: [{name: 'text', type: 'string', title: 'Text'}],
           preview: {
-            select: { title: 'text' },
+            select: {title: 'text'},
           },
         },
       ],

--- a/apps/studio/schemaTypes/utils/isUniqueSlugByLang.ts
+++ b/apps/studio/schemaTypes/utils/isUniqueSlugByLang.ts
@@ -1,0 +1,24 @@
+import type {SlugIsUniqueFn} from 'sanity'
+
+export const isUniqueSlugByLang: SlugIsUniqueFn = async (slug, context) => {
+  const {document, getClient} = context
+  const currentId = document?._id?.replace(/^drafts\./, '')
+  const draftId = currentId ? `drafts.${currentId}` : undefined
+  const language = (document as {language?: string} | undefined)?.language
+
+  if (!slug?.current || !language) return true
+
+  const client = getClient({apiVersion: '2023-10-16'})
+  const query =
+    '*[_type == $type && slug.current == $slug && language == $language && !(_id in [$id, $draftId])][0]._id'
+  const params = {
+    type: document?._type,
+    slug: slug.current,
+    language,
+    id: currentId,
+    draftId,
+  }
+
+  const existingId = await client.fetch<string | null>(query, params)
+  return !existingId
+}

--- a/docs/google-indexing-remediation-plan.md
+++ b/docs/google-indexing-remediation-plan.md
@@ -44,11 +44,22 @@ Make Google consistently select `https://www.pershyykrok.nl` as canonical host a
 ## Rollout checklist
 
 - [x] Platform redirect configured as permanent from bare -> www (`apps/web/vercel.json`).
-- [x] Bare-domain root redirects directly to `https://www.pershyykrok.nl/ua` to avoid an extra `/` -> `/ua` hop.
+- [x] Bare-domain root reaches `https://www.pershyykrok.nl/ua` through permanent redirects.
 - [x] `siteSettings.seo.canonicalBaseUrl` defaults to `https://www.pershyykrok.nl` in Studio schema.
-- [ ] Sitemap/robots inspected in production and aligned to `www`.
+- [x] Sitemap/robots inspected in production and aligned to `www` (verified 2026-05-22).
 - [x] Internal hardcoded bare-domain links replaced (repo audit found no bare-domain app links).
 - [ ] Search Console re-submission and monitoring started.
+
+## Production verification notes
+
+Checked 2026-05-22:
+
+- `https://pershyykrok.nl/ua` and `/ru` return permanent `308` redirects to the `www` host.
+- `https://www.pershyykrok.nl/ua/` and `/ru/` return `200` and emit canonical, `hreflang`, and `og:url` values on `www`.
+- `https://www.pershyykrok.nl/robots.txt` advertises `https://www.pershyykrok.nl/sitemap.xml`.
+- `https://www.pershyykrok.nl/sitemap.xml` contains only `www` URLs.
+
+One minor note: `https://pershyykrok.nl/` currently reaches `/ua` through two permanent redirects (`bare root -> www root -> /ua`). This is not a blocker for canonicalization because both hops are permanent and end on the canonical host, but the Vercel domain redirect can be adjusted later if a single-hop root redirect is desired.
 
 ## Expected outcome
 

--- a/docs/sanity-schema-deploy.md
+++ b/docs/sanity-schema-deploy.md
@@ -5,8 +5,9 @@
 `.github/workflows/deploy-sanity-schema.yml` deploys the Studio schema after schema files change on `main`.
 It is separate from the Vercel web/studio deployments. A failure here does not necessarily mean the public website is down.
 
-The workflow first regenerates `apps/studio/schema.json`. If schema source files changed but the generated schema is
-unchanged, the deploy step is skipped because there is no schema shape update to publish.
+The workflow first regenerates `apps/studio/schema.json` and compares it with the previous `main` revision. If schema
+source files changed but the generated schema is unchanged, the deploy step is skipped because there is no schema shape
+update to publish.
 
 ## Required Token
 

--- a/docs/sanity-schema-deploy.md
+++ b/docs/sanity-schema-deploy.md
@@ -5,6 +5,9 @@
 `.github/workflows/deploy-sanity-schema.yml` deploys the Studio schema after schema files change on `main`.
 It is separate from the Vercel web/studio deployments. A failure here does not necessarily mean the public website is down.
 
+The workflow first regenerates `apps/studio/schema.json`. If schema source files changed but the generated schema is
+unchanged, the deploy step is skipped because there is no schema shape update to publish.
+
 ## Required Token
 
 The workflow uses the repository secret `SANITY_AUTH_TOKEN`.
@@ -27,6 +30,9 @@ User is missing required grant sanity.project/deployStudio
 
 then the repository secret exists, but the token does not have enough Sanity permissions. Replace `SANITY_AUTH_TOKEN`
 with a token that has the required grant, then re-run the workflow.
+
+Shape-neutral refactors, such as moving shared Studio helper code without changing the generated schema, should not
+require this token because the workflow skips deployment when `apps/studio/schema.json` is unchanged.
 
 ## What Not To Do
 

--- a/docs/sanity-schema-deploy.md
+++ b/docs/sanity-schema-deploy.md
@@ -1,0 +1,35 @@
+# Sanity Schema Deploy Workflow
+
+## Purpose
+
+`.github/workflows/deploy-sanity-schema.yml` deploys the Studio schema after schema files change on `main`.
+It is separate from the Vercel web/studio deployments. A failure here does not necessarily mean the public website is down.
+
+## Required Token
+
+The workflow uses the repository secret `SANITY_AUTH_TOKEN`.
+
+That token must have schema/studio deploy access for Sanity project `n1ug74wc`, including the grant:
+
+```text
+sanity.project/deployStudio
+```
+
+In Sanity, create this as a Developer-level token for the project. An Editor token is not sufficient.
+
+## Common Failure
+
+If the workflow fails with:
+
+```text
+User is missing required grant sanity.project/deployStudio
+```
+
+then the repository secret exists, but the token does not have enough Sanity permissions. Replace `SANITY_AUTH_TOKEN`
+with a token that has the required grant, then re-run the workflow.
+
+## What Not To Do
+
+- Do not print the token in logs.
+- Do not commit tokens or `.env*` files.
+- Do not ask an AI agent to create or modify repository secrets; a repository/Sanity owner must do that.


### PR DESCRIPTION
## Goal

This PR makes the project easier and safer to maintain with both human and AI-assisted contributors.

It adds clear repo-local guidance for future agents, improves GitHub issue/PR structure, reduces duplicated Sanity Studio schema code, and makes the Sanity schema deployment workflow smarter so harmless Studio refactors do not create avoidable failure notifications.

## What Improves

### Clearer AI and human collaboration

- Adds `AGENTS.md` as the shared working guide for Codex, Claude, Antigravity, Copilot, and human reviewers.
- Adds a PR template and an AI-task issue template so future work has clearer scope, validation, and production-safety notes.
- Documents expectations around secrets, Sanity content, generated files, locale symmetry, and production-sensitive changes.

### Safer Sanity schema deployment

- Documents the exact `SANITY_AUTH_TOKEN` requirement for real schema deploys: project `n1ug74wc` needs the `sanity.project/deployStudio` grant.
- Adds a preflight message so missing or insufficient deploy-token permissions are easier to diagnose.
- Regenerates `apps/studio/schema.json` during the workflow and compares it with the previous `main` revision.
- Skips `sanity schema deploy` only when schema source files changed but the generated schema shape did not change.
- Still deploys conservatively for manual workflow runs, unavailable base commits, and real generated-schema changes.

### Cleaner Studio schema maintenance

- Moves the duplicated `isUniqueSlugByLang` logic into one shared Studio helper.
- Updates page, FAQ, and self-test schemas to use the shared helper without changing behavior.
- Marks the completed slug-helper TODO as done.

### SEO and operations clarity

- Records production verification for the Google indexing/canonical-host work.
- Updates the preview URL example to the canonical `https://www.pershyykrok.nl` host.

## Issue Links

- References #6: production canonical-host signals are documented as aligned; Search Console monitoring remains external.
- References #13: workflow/docs improve diagnosis; owner token update is still needed for real schema deployments.
- Closes #14: shared Studio slug uniqueness helper restored.

## Safety Notes

This is a clean re-apply of the approved maintenance work after PR #16 reverted the contaminated PR #15 squash merge.

Safety checks specific to that incident:

- `apps/web/astro.config.mjs` is not changed in this PR.
- Current `origin/main` has the clean 348-byte `apps/web/astro.config.mjs` blob.
- A scan for the injected payload markers (`global.i`, `_$_`, `740160`, `6342606`, `createRequire(import.meta.url)`) found no matches in this branch.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/deploy-sanity-schema.yml'); YAML.load_file('.github/ISSUE_TEMPLATE/ai-task.md'); puts 'yaml ok'"` -> passed.
- `CI=true pnpm --filter studio codemod` -> passed; generated schema/types unchanged.
- `CI=true pnpm --filter studio build` -> passed, with existing Sanity auto-update/runtime-version warnings.
- `CI=true pnpm --filter web build` -> passed, with existing Astro/Vercel environment hints.
- `CI=true pnpm --filter studio extract && git diff --quiet origin/main -- apps/studio/schema.json` -> passed; this PR has no generated schema shape change.
- `git diff --check` -> passed.
- Vercel web/studio PR checks -> passed.
- Codex re-review after the workflow fix -> no major issues.

## Remaining External Action

No production content, Vercel settings, GitHub secrets, or Sanity project settings are changed here.

For future real schema deployments, a repo/Sanity owner still needs to update `SANITY_AUTH_TOKEN` with a Sanity token that has `sanity.project/deployStudio` for project `n1ug74wc`.
