### PR TITLE
Add meeting reading resource links

### DIFF
--- a/apps/web/src/components/HomePageContent.astro
+++ b/apps/web/src/components/HomePageContent.astro
@@ -111,20 +111,20 @@ const mapEmbedUrl =
         )}
       </div>
 
-      <div class="mt-5 grid grid-cols-1 md:grid-cols-2 gap-4">
+      <div class="mt-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {resourceItems.map((item) => (
           <a
             href={item.href!}
             target="_blank"
             rel="noopener noreferrer"
-            class="group block rounded-md border border-gray-200 bg-white p-4 transition-colors hover:border-[#1371AF] focus:outline-none focus:ring-2 focus:ring-[#1371AF] focus:ring-offset-2"
+            class="group flex h-full flex-col rounded-md border border-gray-200 bg-white p-4 transition-colors hover:border-[#1371AF] focus:outline-none focus:ring-2 focus:ring-[#1371AF] focus:ring-offset-2"
           >
             <span class="block font-semibold text-gray-950">{item.label}</span>
             {item.description && (
               <span class="mt-2 block text-sm leading-6 text-gray-700">{item.description}</span>
             )}
             {resourceLinksSection!.linkPrompt && (
-              <span class="mt-3 inline-flex text-sm font-semibold text-[#0B4A78] group-hover:underline">
+              <span class="mt-auto inline-flex pt-3 text-sm font-semibold text-[#0B4A78] group-hover:underline">
                 {resourceLinksSection!.linkPrompt}
               </span>
             )}

--- a/scripts/one-off/seed-homepage-resource-links.mjs
+++ b/scripts/one-off/seed-homepage-resource-links.mjs
@@ -25,9 +25,11 @@ if (fs.existsSync(envPath)) {
   }
 }
 
-const token = env.SANITY_API_WRITE_TOKEN
+const token = env.SANITY_API_WRITE_TOKEN || env.SANITY_AUTH_TOKEN
 if (!token) {
-  console.error('SANITY_API_WRITE_TOKEN not found in the environment or repo-root .env.local')
+  console.error(
+    'SANITY_API_WRITE_TOKEN or SANITY_AUTH_TOKEN not found in the environment or repo-root .env.local',
+  )
   process.exit(1)
 }
 

--- a/scripts/one-off/seed-homepage-resource-links.mjs
+++ b/scripts/one-off/seed-homepage-resource-links.mjs
@@ -41,66 +41,56 @@ const client = createClient({
 
 const resourceLinksByLanguage = {
   ua: {
-    sectionTitle: 'Ресурси АА',
+    sectionTitle: 'Матеріали для читання на зустрічі',
     description:
-      'Перевірені сторінки, де можна знайти нашу групу, інші україномовні зустрічі та загальну інформацію про АА.',
-    linkPrompt: 'Перейти',
+      'Посилання на тексти, які ми зазвичай читаємо під час зустрічі: розділ з Великої Книги, Перший Крок з «12 і 12» та щоденні роздуми.',
+    linkPrompt: 'Відкрити',
     items: [
       {
-        _key: 'aa-netherlands',
-        label: 'Pershyy Krok в AA Netherlands',
-        description: 'Актуальна сторінка нашої групи в офіційному списку зустрічей AA Netherlands.',
-        href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
+        _key: 'big-book-how-it-works',
+        label: '«Як воно діє» з Великої Книги',
+        description: 'Розділ 5 книги «Анонімні Алкоголіки» у PDF на сайті АА України.',
+        href: 'https://aa.org.ua/wp-content/uploads/2024/07/Anonimni-Alkogoliki-internet_25.03.22.pdf#page=72',
       },
       {
-        _key: 'aa-ukraine-abroad',
-        label: 'Україномовні групи за кордоном',
-        description: 'Список АА України з україномовними групами та контактами поза Україною.',
-        href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
+        _key: 'twelve-and-twelve-step-one',
+        label: 'Перший Крок з «12 і 12»',
+        description:
+          'Офіційна сторінка книжки «Дванадцять Кроків і Дванадцять Традицій» українською.',
+        href: 'https://aa.org.ua/literature/dvanadtsiat-krokiv-ta-dvanadtsiat-tradytsiy/',
       },
       {
-        _key: 'aa-continental-europe',
-        label: 'A.A. Continental European Region',
-        description: 'Ресурси АА для англомовних груп у континентальній Європі.',
-        href: 'https://alcoholics-anonymous.eu/',
-      },
-      {
-        _key: 'aa-world-services',
-        label: 'Alcoholics Anonymous',
-        description: 'Головний сайт Alcoholics Anonymous World Services з інформацією про програму АА.',
-        href: 'https://www.aa.org/',
+        _key: 'daily-reflections',
+        label: 'Щоденні роздуми',
+        description: 'Українське видання щоденних роздумів на сайті АА України.',
+        href: 'https://aa.org.ua/wp-content/uploads/2026/05/SHCHodenni-rozdumy-dlia-WEB.pdf',
       },
     ],
   },
   ru: {
-    sectionTitle: 'Ресурсы АА',
+    sectionTitle: 'Материалы для чтения на встрече',
     description:
-      'Проверенные страницы, где можно найти нашу группу, другие украиноязычные встречи и общую информацию об АА.',
-    linkPrompt: 'Перейти',
+      'Ссылки на тексты, которые мы обычно читаем во время встречи: раздел из Большой Книги, Первый Шаг из «12 и 12» и ежедневные размышления.',
+    linkPrompt: 'Открыть',
     items: [
       {
-        _key: 'aa-netherlands',
-        label: 'Pershyy Krok в AA Netherlands',
-        description: 'Актуальная страница нашей группы в официальном списке встреч AA Netherlands.',
-        href: 'https://aa-netherlands.org/aa-meetings/find-a-meeting/pershyy-krok/',
+        _key: 'big-book-how-it-works',
+        label: '«Программа в действии» из Большой Книги',
+        description: 'Глава 5 книги «Анонимные Алкоголики» в PDF на сайте АА Украины.',
+        href: 'https://aa.org.ua/wp-content/uploads/2024/09/Anonimnye-alkogoliki.-S-istoriyami.pdf#page=92',
       },
       {
-        _key: 'aa-ukraine-abroad',
-        label: 'Украиноязычные группы за рубежом',
-        description: 'Список АА Украины с украиноязычными группами и контактами за пределами Украины.',
-        href: 'https://aa.org.ua/ukrainomovni-hrupy-za-kordonom/',
+        _key: 'twelve-and-twelve-step-one',
+        label: 'Первый Шаг из «12 и 12»',
+        description:
+          'Официальная страница книги «Двенадцать Шагов и Двенадцать Традиций» на русском.',
+        href: 'https://aa.org.ua/literature/dvenadtsat-shahov-y-dvenadtsat-tradytsyy/',
       },
       {
-        _key: 'aa-continental-europe',
-        label: 'A.A. Continental European Region',
-        description: 'Ресурсы АА для англоязычных групп в континентальной Европе.',
-        href: 'https://alcoholics-anonymous.eu/',
-      },
-      {
-        _key: 'aa-world-services',
-        label: 'Alcoholics Anonymous',
-        description: 'Главный сайт Alcoholics Anonymous World Services с информацией о программе АА.',
-        href: 'https://www.aa.org/',
+        _key: 'daily-reflections',
+        label: 'Ежедневные размышления',
+        description: 'Русская страница ежедневных размышлений на сайте АА Украины.',
+        href: 'https://aa.org.ua/literature/shchodenni-rozdumy/',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Update the homepage resource-link seed content to localized meeting readings for Ukrainian and Russian visitors.
- Link to the Big Book reading, Step 1 from the 12 & 12 book pages, and Daily Reflections on AA Ukraine resources.
- Adjust homepage resource cards to fit three meeting-reading links cleanly on wider screens.
- Allow the seed script to use the existing repository secret name `SANITY_AUTH_TOKEN`, with `SANITY_API_WRITE_TOKEN` still supported for local runs.

## Validation

- [x] `node --check scripts/one-off/seed-homepage-resource-links.mjs`
- [x] `git diff --check`
- [x] `CI=true pnpm --filter web build`
- [x] Verified all six AA Ukraine resource URLs return HTTP 200.
- [x] Smoke-tested `/ua/` and `/ru/` on the local dev server; both returned HTTP 200 and rendered the updated card grid classes.
- [x] No schema/query shape changed; generated Sanity types did not need updates.
- [x] Checked production-sensitive effects: no secrets changed or printed; `gh secret list` confirms `SANITY_AUTH_TOKEN` exists, but secret values are not readable locally.

## Notes

- Changed surfaces: web, scripts/Sanity content seed.
- External action after approval/merge: run `SANITY_AUTH_TOKEN=... node scripts/one-off/seed-homepage-resource-links.mjs` to publish the new localized resource links into Sanity production.
- Pre-existing build hints/warnings observed: unused generated `ArrayOf`, inline GTM script hint, dynamic route `getStaticPaths()` warnings, and local Node 25 vs Vercel Node 22 warning.
